### PR TITLE
Add a new cbz converter binary (mobi/azw3/pdf only for now)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,10 +397,33 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "camino",
+ "clap",
  "glob",
+ "image",
  "sanitize-filename",
  "thiserror",
+ "tracing",
  "zip",
+]
+
+[[package]]
+name = "cbz-converter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cbz",
+ "cbz-pack",
+ "clap",
+ "html5ever 0.26.0",
+ "image",
+ "markup5ever_rcdom",
+ "mobi",
+ "pdf",
+ "sanitize-filename",
+ "tl",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -437,12 +460,9 @@ dependencies = [
  "camino",
  "cbz",
  "clap",
- "futures",
  "glob",
- "image",
- "pdf",
  "sanitize-filename",
- "tokio",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1177,6 +1197,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,7 +1960,21 @@ checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.10.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2270,7 +2368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea8e9c6e031377cff82ee3001dc8026cdf431ed4e2e6b51f98ab8c73484a358"
 dependencies = [
  "cssparser",
- "html5ever",
+ "html5ever 0.25.2",
  "matches",
  "selectors",
 ]
@@ -2350,10 +2448,36 @@ checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
 dependencies = [
  "log",
  "phf 0.8.0",
- "phf_codegen",
+ "phf_codegen 0.8.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
+dependencies = [
+ "html5ever 0.26.0",
+ "markup5ever 0.11.0",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -2418,6 +2542,17 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mobi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3f8e34216126be00a189105bda27462e1743d59cd4e15d6b99ff4af051b1b4"
+dependencies = [
+ "encoding",
+ "indexmap 1.9.3",
+ "thiserror",
 ]
 
 [[package]]
@@ -2837,6 +2972,15 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
@@ -2852,6 +2996,16 @@ checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
 dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -3459,7 +3613,7 @@ dependencies = [
  "log",
  "matches",
  "phf 0.8.0",
- "phf_codegen",
+ "phf_codegen 0.8.0",
  "precomputed-hash",
  "servo_arc",
  "smallvec",
@@ -4017,6 +4171,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tl"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e993a1c7c32fdf90a308cec4d457f507b2573acc909bd6e7a092321664fdb3"
 
 [[package]]
 name = "to_method"
@@ -4787,7 +4947,7 @@ dependencies = [
  "gio",
  "glib",
  "gtk",
- "html5ever",
+ "html5ever 0.25.2",
  "http",
  "javascriptcore-rs",
  "kuchiki",
@@ -4829,6 +4989,17 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "dexter",
   "dexter-core",
   "cbz",
+  "cbz-converter",
   "cbz-dexter-reindex",
   "cbz-merge",
   "cbz-pack",
@@ -12,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-rust-version = "1.72.0"
+rust-version = "1.72.1"
 edition = "2021"
 
 [workspace.dependencies]
@@ -23,6 +24,7 @@ base64 = "0.21.2"
 bytes = "1.4.0"
 camino = "1.1.4"
 cbz = { path = "./cbz" }
+cbz-pack = { path = "./cbz-pack" }
 cbz-reader = { path = "./cbz-reader" }
 clap = { version = "4.3.5", features = ["derive"] }
 cli-table = "0.4.7"
@@ -33,15 +35,20 @@ dioxus-desktop = "0.4.0"
 futures = "0.3.28"
 glob = "0.3.1"
 home = "0.5.5"
+html5ever = "0.26.0"
 image = "0.24.6"
 indicatif = "0.17.5"
 isolang = "2.0"
+markup5ever_rcdom = "0.2.0"
+mime = "0.3.17"
+mobi = "0.8.0"
 pdf = "0.8.1"
 reqwest = "0.11.18"
 reqwest-middleware = "0.2.2"
 reqwest-retry = "0.2.2"
 sanitize-filename = "0.4.0"
 serde = "1.0.164"
+tl = "0.7.7"
 thiserror = "1.0.40"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"

--- a/README.md
+++ b/README.md
@@ -83,12 +83,6 @@ dexter download -c 07bf2a09-f30d-410f-aba1-025e2d27a88f -o
 
 That'll automatically download the whole chapter as a CBZ file and open it in the simple `cbz-reader` which source is also available in this repository.
 
-## Cbz Reader
-
-```bash
-cbz-reader archive.cbz
-```
-
 ## Cbz Merge
 
 This will look for all the Cbz archives file foundable in `path` and which file name contains `something` and merge into `output/merged_archive.cbz`:
@@ -97,7 +91,7 @@ This will look for all the Cbz archives file foundable in `path` and which file 
 cbz-merge --archives-glob "path/**/*something*" --outdir "output" --name "merged_archive"
 ```
 
-## Cbz Reader
+## Cbz Pack
 
 Takes all the `png` files under `source` and pack them into the `archive.cbz` file:
 
@@ -112,6 +106,15 @@ cbz-pack source.pdf --pdf --name archive
 ```
 
 Options inclue:
+
 - `--autosplit`: split in 2 landscape images
 - `--contrast`: change contrast
 - `--brightness`: change brightness
+
+## Cbz Converter
+
+Converts from \* to cbz (only pdf, mobi, and DRM-free azw3 supported for the moment):
+
+```bash
+cbz-converter "archive.azw3" --from azw3 --outdir out
+```

--- a/cbz-converter/Cargo.toml
+++ b/cbz-converter/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "cbz-converter"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+camino.workspace = true
+cbz.workspace = true
+cbz-pack.workspace = true
+clap.workspace = true
+html5ever = { workspace = true, optional = true }
+image.workspace = true
+markup5ever_rcdom = { workspace = true, optional = true }
+mobi.workspace = true
+pdf.workspace = true
+sanitize-filename.workspace = true
+tl.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[features]
+default = []
+html5ever = ["dep:html5ever", "markup5ever_rcdom"]

--- a/cbz-converter/src/main.rs
+++ b/cbz-converter/src/main.rs
@@ -1,25 +1,41 @@
-#![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 
-use std::{env, fs::create_dir};
+use std::fs;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use camino::Utf8PathBuf;
 use cbz::image::ReadingOrder;
-use cbz_pack::{get_images_from_glob, pack_imgs_to_cbz};
-use clap::Parser;
-use tracing::debug;
+use cbz_pack::pack_imgs_to_cbz;
+use clap::{Parser, ValueEnum};
+use tracing::{debug, info};
 
-#[derive(Parser, Debug)]
-#[clap(about, author, version)]
-pub struct Args {
-    /// A glob that matches all the files to pack
-    files_descriptor: String,
-    /// The output directory for the merged archive
-    #[clap(short, long, default_value = "./")]
+use crate::mobi::convert_to_imgs as mobi_to_imgs;
+use crate::pdf::convert_to_imgs as pdf_to_imgs;
+
+mod mobi;
+mod pdf;
+mod utils;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Format {
+    Mobi,
+    Azw3,
+    Pdf,
+}
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the source file
+    path: Utf8PathBuf,
+    /// Source format
+    #[clap(long, short)]
+    from: Format,
+    /// Dir to output images
+    #[clap(long, short)]
     outdir: Utf8PathBuf,
-    /// The merged archive name
-    #[clap(short, long)]
+    /// The archive name
+    #[clap(long, short)]
     name: String,
     /// Adjust images contrast
     #[clap(long)]
@@ -42,14 +58,12 @@ fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let args = Args::parse();
-    let Ok(current_dir) = Utf8PathBuf::from_path_buf(env::current_dir()?) else {
-        bail!("current dir is not a valid utf-8 path");
+    fs::create_dir_all(&args.outdir)?;
+    let imgs = match args.from {
+        Format::Mobi | Format::Azw3 => mobi_to_imgs(args.path)?,
+        Format::Pdf => pdf_to_imgs(args.path)?,
     };
-    let outdir = current_dir.join(&args.outdir);
-    if !outdir.exists() {
-        create_dir(&*outdir)?;
-    }
-    let imgs = get_images_from_glob(args.files_descriptor)?;
+    info!("found {} imgs", imgs.len());
 
     let out_cbz_writer_finished = pack_imgs_to_cbz(
         imgs,
@@ -60,7 +74,9 @@ fn main() -> Result<()> {
         args.reading_order,
     )?;
 
-    let output_path = outdir.join(sanitize_filename::sanitize(format!("{}.cbz", args.name)));
+    let output_path = args
+        .outdir
+        .join(sanitize_filename::sanitize(format!("{}.cbz", args.name)));
     debug!("writing cbz file to {output_path}");
 
     out_cbz_writer_finished.write_to_path(output_path)?;

--- a/cbz-converter/src/mobi/html5ever_parser.rs
+++ b/cbz-converter/src/mobi/html5ever_parser.rs
@@ -1,0 +1,85 @@
+use std::{fs, io::BufReader, path::Path};
+
+use anyhow::Result;
+use cbz::image::Image;
+use html5ever::{parse_document, tendril::TendrilSink, ParseOpts};
+use markup5ever_rcdom::{Node, NodeData, RcDom};
+use mobi::Mobi;
+use tracing::error;
+
+use crate::utils::base_32;
+
+use super::MobiVersion;
+
+pub fn convert_to_imgs(path: impl AsRef<Path>) -> Result<Vec<Image>> {
+    let mobi = Mobi::from_path(path)?;
+    // Or is it `gen_version`? Both were equal in all the files I tested.
+    let version = MobiVersion::try_from(mobi.metadata.mobi.format_version)?;
+    let dom = get_dom(&mobi)?;
+    let imgs = mobi.image_records();
+    let mut all_imgs = Vec::with_capacity(imgs.len());
+    visit_node(version, &dom.document, |fid| {
+        if let Some(img) = imgs.get(fid) {
+            match Image::from_bytes(img.content) {
+                Ok(img) => all_imgs.push(img),
+                Err(err) => error!("failed to decode image: {err}"),
+            };
+        } else {
+            println!("unknown fid {fid}");
+        }
+    });
+    Ok(all_imgs)
+}
+
+fn get_dom(m: &Mobi) -> Result<RcDom> {
+    let html = m.content_as_string_lossy();
+    fs::write("index.html", html.as_bytes())?;
+    let mut buf = BufReader::new(html.as_bytes());
+    let dom = parse_document(RcDom::default(), ParseOpts::default())
+        .from_utf8()
+        .read_from(&mut buf)?;
+    Ok(dom)
+}
+
+fn visit_node<F>(version: MobiVersion, node: &Node, mut f: F)
+where
+    F: FnMut(usize),
+{
+    visit_node_impl(version, node, &mut f);
+}
+
+fn visit_node_impl<F>(version: MobiVersion, node: &Node, f: &mut F)
+where
+    F: FnMut(usize),
+{
+    for node in node.children.borrow().iter() {
+        if let NodeData::Element { name, attrs, .. } = &node.data {
+            if name.local.as_ref() == "img" {
+                for attr in attrs.borrow().iter() {
+                    if version == MobiVersion::Mobi6 && attr.name.local.as_ref() == "recindex" {
+                        let recindex: &str = attr.value.as_ref();
+                        let fid = String::from_utf8_lossy(recindex.as_bytes())
+                            .parse()
+                            .unwrap();
+                        f(fid);
+                        continue;
+                    }
+                    if version == MobiVersion::Mobi8 && attr.name.local.as_ref() == "src" {
+                        let src: &str = attr.value.as_ref();
+                        // Encoding may be broken so we use a "best effort" strategy
+                        // instead of simply extracting the fid and mime type from the string
+                        let Some(index) = src.find("?mime=") else {
+                            println!("mime type not found for {src}");
+                            continue;
+                        };
+                        // We assume the code is running on a 64bit system, so it's safe to unwrap
+                        let fid =
+                            usize::try_from(base_32(src[index - 4..index].as_bytes())).unwrap() - 1;
+                        f(fid);
+                    }
+                }
+            }
+        }
+        visit_node_impl(version, node, f);
+    }
+}

--- a/cbz-converter/src/mobi/mod.rs
+++ b/cbz-converter/src/mobi/mod.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "html5ever")]
+pub use html5ever_parser::convert_to_imgs;
+#[cfg(not(feature = "html5ever"))]
+pub use tl_parser::convert_to_imgs;
+
+#[cfg(feature = "html5ever")]
+mod html5ever_parser;
+#[cfg(not(feature = "html5ever"))]
+mod tl_parser;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum MobiVersion {
+    Mobi6,
+    Mobi8,
+}
+
+impl TryFrom<u32> for MobiVersion {
+    type Error = anyhow::Error;
+
+    fn try_from(version: u32) -> std::result::Result<Self, Self::Error> {
+        match version {
+            6 => Ok(Self::Mobi6),
+            8 => Ok(Self::Mobi8),
+            _ => anyhow::bail!("invalid version {version}"),
+        }
+    }
+}

--- a/cbz-converter/src/mobi/tl_parser.rs
+++ b/cbz-converter/src/mobi/tl_parser.rs
@@ -1,0 +1,103 @@
+use std::path::Path;
+
+use anyhow::Result;
+use cbz::image::Image;
+use mobi::Mobi;
+use tl::{HTMLTag, ParserOptions, VDom};
+use tracing::{debug, error, warn};
+
+use crate::utils::base_32;
+
+use super::MobiVersion;
+
+pub fn convert_to_imgs(path: impl AsRef<Path>) -> Result<Vec<Image>> {
+    let mobi = Mobi::from_path(path)?;
+    // Or is it `gen_version`? Both were equal in all the files I tested.
+    let version = MobiVersion::try_from(mobi.metadata.mobi.format_version)?;
+    debug!("mobi version {version:#?}");
+    let imgs = mobi.image_records();
+    debug!("found {} images", imgs.len());
+    let html = mobi.content_as_string_lossy();
+    let dom = tl::parse(&html, ParserOptions::default())?;
+    let mut all_imgs = Vec::with_capacity(imgs.len());
+    for_each_fid(version, &dom, |fid| {
+        if let Some(img) = imgs.get(fid) {
+            match Image::from_bytes(img.content) {
+                Ok(img) => all_imgs.push(img),
+                Err(err) => error!("failed to decode image: {err}"),
+            };
+        } else {
+            warn!("unknown fid {fid}");
+        }
+    });
+    Ok(all_imgs)
+}
+
+fn for_each_fid<F>(version: MobiVersion, dom: &VDom, mut f: F)
+where
+    F: FnMut(usize),
+{
+    // By no mean a perfect implementation of a mobi/azw3 interpreter,
+    // the documentation is very sparse and no proper specs are accessible,
+    // it's mostly guess work and best effort.
+    match version {
+        MobiVersion::Mobi6 => {
+            for_each_tag(dom, "img[recindex]", |tag| {
+                let Some(Some(recindex)) = tag.attributes().get("recindex") else {
+                    return;
+                };
+                let fid = String::from_utf8_lossy(recindex.as_bytes())
+                    .parse()
+                    .unwrap();
+
+                f(fid);
+            });
+        }
+        MobiVersion::Mobi8 => {
+            for_each_tag(dom, "img[src]", |tag| {
+                let Some(Some(src)) = tag.attributes().get("src") else {
+                    debug!("tag has no src attribute, or it's invalid {tag:#?}");
+                    return;
+                };
+                let src = src.as_utf8_str();
+                // Encoding may be broken, we use a "best effort" strategy
+                // instead of simply extracting the fid and mime type from the string
+                let Some(mime_index) = src.find("?mime=") else {
+                    warn!("mime type not found for {src}");
+                    return;
+                };
+                // We assume the code is running on a 64bit system, so it's safe to unwrap
+                let fid = usize::try_from(base_32(src[mime_index - 4..mime_index].as_bytes()))
+                    .unwrap()
+                    - 1;
+                // Mime is unused for now but could be handy later on, let's keep it for now
+                // let Ok::<Mime, _>(mime_type) = src[mime_index + 6..].parse() else {
+                //     warn!("invalid mime type for {mime_index} {src}");
+                //     return;
+                // };
+                f(fid);
+            });
+        }
+    }
+}
+
+fn for_each_tag<F>(dom: &VDom, selector: &str, mut f: F)
+where
+    F: FnMut(&HTMLTag<'_>),
+{
+    let Some(node_handles) = dom.query_selector(selector) else {
+        debug!("no nodes found");
+        return;
+    };
+    for node_handle in node_handles {
+        let Some(node) = node_handle.get(dom.parser()) else {
+            debug!("node not found {}", node_handle.get_inner());
+            continue;
+        };
+        let Some(tag) = node.as_tag() else {
+            debug!("node is not a tag {node:#?}");
+            continue;
+        };
+        f(tag);
+    }
+}

--- a/cbz-converter/src/pdf.rs
+++ b/cbz-converter/src/pdf.rs
@@ -1,0 +1,51 @@
+use std::{io::Cursor, path::Path};
+
+use anyhow::Result;
+use cbz::image::Image;
+use pdf::{
+    enc::StreamFilter,
+    file::FileOptions as PdfFileOptions,
+    object::{Resolve, XObject},
+};
+use tracing::error;
+
+pub fn convert_to_imgs(path: impl AsRef<Path>) -> Result<Vec<Image>> {
+    let pdf = PdfFileOptions::cached().open(path)?;
+    // We may have actually less images than the count but never more,
+    // at worse we request a slightly bigger capacity than necessary but at best we prevent any further allocations.
+    let mut imgs = Vec::with_capacity(pdf.pages().count());
+
+    for page in pdf.pages() {
+        for resource in page?.resources()?.xobjects.values() {
+            let resource = match pdf.get(*resource) {
+                Ok(resource) => resource,
+                Err(err) => {
+                    error!("failed to get resource from pdf: {err}");
+                    continue;
+                }
+            };
+            if let XObject::Image(image) = &*resource {
+                let (image, filter) = match image.raw_image_data(&pdf) {
+                    Ok(image_data) => image_data,
+                    Err(err) => {
+                        error!("failed to get image data: {err}");
+                        continue;
+                    }
+                };
+                if let Some(StreamFilter::DCTDecode(_)) = filter {
+                    let img = match Image::from_reader(Cursor::new(&image)) {
+                        Ok(img) => img,
+                        Err(err) => {
+                            error!("image couldn't be read: {err}");
+                            continue;
+                        }
+                    };
+                    imgs.push(img);
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(imgs)
+}

--- a/cbz-converter/src/utils.rs
+++ b/cbz-converter/src/utils.rs
@@ -1,0 +1,29 @@
+static BASE_32_SCALELST: [u64; 8] = [
+    1,
+    32,
+    1_024,
+    32_768,
+    1_048_576,
+    33_554_432,
+    1_073_741_824,
+    34_359_738_368,
+];
+
+// Adapted from https://github.com/iscc/mobi/blob/cb9ad8fd261f23d669c7e2d56a7a34b5aff29036/mobi/mobi_utils.py#L216
+// The base32 crate didn't work in our case
+pub fn base_32(bytes: &[u8]) -> u64 {
+    let mut value = 0;
+    let mut scale = 0;
+    for (i, byte) in bytes.iter().rev().enumerate() {
+        let v = if byte.is_ascii_digit() {
+            byte - b'0'
+        } else {
+            byte - b'A' + 10
+        };
+        scale = BASE_32_SCALELST.get(i).copied().unwrap_or(scale * 32);
+        if v != 0 {
+            value += (u64::from(v)) * scale;
+        }
+    }
+    value
+}

--- a/cbz-dexter-reindex/src/main.rs
+++ b/cbz-dexter-reindex/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
 /// Indices are often ill formatted or invalid (x1, R2, etc...).
 /// This function will clean up the index and add some padding (3).
 ///
-/// # Errors
+/// ## Errors
 ///
 /// Fails if the filename is empty or the index is invalid (longer than the `expected_length` or not a valid unsigned integer).
 pub fn reformat_index(cbz_file: &CbzFile, expected_length: usize) -> Result<String> {

--- a/cbz-pack/Cargo.toml
+++ b/cbz-pack/Cargo.toml
@@ -7,17 +7,10 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true
-cbz.workspace = true
+cbz = { workspace = true, features = ["clap"] }
 clap.workspace = true
 tracing-subscriber.workspace = true
-futures.workspace = true
 glob.workspace = true
-image.workspace = true
-tracing.workspace = true
-pdf = { workspace = true, optional = true }
 sanitize-filename.workspace = true
-tokio.workspace = true
-
-[features]
-default = ["pdf"]
-pdf = ["dep:pdf"]
+thiserror.workspace = true
+tracing.workspace = true

--- a/cbz-pack/src/errors.rs
+++ b/cbz-pack/src/errors.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("error: {0}")]
+    Generic(String),
+
+    #[error("Glob error: {0}")]
+    Glob(#[from] glob::GlobError),
+
+    #[error("Glob pattern error: {0}")]
+    GlobPattern(#[from] glob::PatternError),
+
+    #[error("Cbz error: {0}")]
+    Image(#[from] cbz::Error),
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/cbz-pack/src/lib.rs
+++ b/cbz-pack/src/lib.rs
@@ -1,0 +1,71 @@
+#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+
+use std::io::Cursor;
+
+use camino::Utf8Path;
+use cbz::{
+    image::{Image, ReadingOrder},
+    CbzWriter, CbzWriterFinished, COUNTER_SIZE,
+};
+use glob::glob;
+use tracing::{debug, error};
+
+use crate::errors::Result;
+
+pub mod errors;
+
+/// ## Errors
+///
+/// Fails when the glob is invalid, the paths are not utf-8, or the image can't be read and decoded
+pub fn get_images_from_glob(glob_expr: impl AsRef<str>) -> Result<Vec<Image>> {
+    let paths = glob(glob_expr.as_ref())?;
+    let mut imgs = Vec::new();
+
+    for path in paths {
+        let path = path?;
+        let Some(path) = Utf8Path::from_path(&path) else {
+            error!("{path:?} is not a valid utf-8 path");
+            continue;
+        };
+        imgs.push(Image::open(path)?);
+    }
+
+    Ok(imgs)
+}
+
+#[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+pub fn pack_imgs_to_cbz(
+    imgs: Vec<Image>,
+    contrast: Option<f32>,
+    brightness: Option<i32>,
+    blur: Option<f32>,
+    autosplit: bool,
+    reading_order: ReadingOrder,
+) -> Result<CbzWriterFinished<Cursor<Vec<u8>>>> {
+    let mut out_cbz_writer = CbzWriter::default();
+    for (i, mut img) in imgs.into_iter().enumerate() {
+        if let Some(contrast) = contrast {
+            img = img.set_contrast(contrast);
+        }
+        if let Some(brightness) = brightness {
+            img = img.set_brightness(brightness);
+        }
+        if let Some(blur) = blur {
+            img = img.set_blur(blur);
+        }
+
+        if img.is_landscape() && autosplit {
+            debug!("splitting landscape file");
+            let (img_left, img_right) = img.autosplit(reading_order);
+            img_left
+                .insert_into_cbz_writer(&mut out_cbz_writer, format!("{i:0>COUNTER_SIZE$}-1"))?;
+            img_right
+                .insert_into_cbz_writer(&mut out_cbz_writer, format!("{i:0>COUNTER_SIZE$}-2"))?;
+        } else {
+            img.insert_into_cbz_writer(&mut out_cbz_writer, format!("{i:0>COUNTER_SIZE$}"))?;
+        }
+    }
+
+    Ok(out_cbz_writer.finish()?)
+}

--- a/cbz/Cargo.toml
+++ b/cbz/Cargo.toml
@@ -6,8 +6,15 @@ rust-version.workspace = true
 
 [dependencies]
 bytes.workspace = true
+clap = { workspace = true, optional = true }
 camino.workspace = true
 glob.workspace = true
+image.workspace = true
 sanitize-filename.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 zip.workspace = true
+
+[features]
+default = []
+clap = ["dep:clap"]

--- a/cbz/src/errors.rs
+++ b/cbz/src/errors.rs
@@ -30,6 +30,9 @@ pub enum Error {
 
     #[error("Cbz file insertion: no bytes set")]
     CbzInsertionNoBytes,
+
+    #[error("Image error: {0}")]
+    Image(#[from] image::ImageError),
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T, E = Error> = result::Result<T, E>;

--- a/cbz/src/image.rs
+++ b/cbz/src/image.rs
@@ -1,0 +1,156 @@
+use std::{
+    fmt::Display,
+    io::{BufRead, Cursor, Seek},
+    path::Path,
+};
+
+use image::{io::Reader as ImageReader, DynamicImage, ImageFormat};
+use tracing::debug;
+
+use crate::{CbzWrite, CbzWriterInsertionBuilder, Result};
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+pub enum ReadingOrder {
+    Rtl,
+    Ltr,
+}
+
+impl Display for ReadingOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Ltr => "ltr",
+                Self::Rtl => "rtl",
+            }
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Image {
+    dynamic_image: DynamicImage,
+    format: Option<ImageFormat>,
+}
+
+impl Image {
+    /// ## Errors
+    ///
+    /// Fails if the image can't be open or decoded
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let reader = ImageReader::open(&path)?;
+        let format = reader.format();
+        Ok(Self {
+            dynamic_image: reader.decode()?,
+            format,
+        })
+    }
+
+    /// ## Errors
+    ///
+    /// Fails if the image format can't be guessed or the image can't be decoded
+    pub fn from_reader(reader: impl BufRead + Seek) -> Result<Self> {
+        let reader = ImageReader::new(reader).with_guessed_format()?;
+        let format = reader.format();
+        Ok(Self {
+            dynamic_image: reader.decode()?,
+            format,
+        })
+    }
+
+    /// ## Errors
+    ///
+    /// Fails if the image format can't be guessed or the image can't be decoded
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let buf_reader = Cursor::new(bytes);
+        let reader = ImageReader::new(buf_reader).with_guessed_format()?;
+        let format = reader.format();
+        Ok(Self {
+            dynamic_image: reader.decode()?,
+            format,
+        })
+    }
+
+    fn from_dynamic_image(dynamic_image: DynamicImage, format: Option<ImageFormat>) -> Self {
+        Self {
+            dynamic_image,
+            format,
+        }
+    }
+
+    #[must_use]
+    pub fn is_portrait(&self) -> bool {
+        self.dynamic_image.height() > self.dynamic_image.width()
+    }
+
+    #[must_use]
+    pub fn is_landscape(&self) -> bool {
+        !self.is_portrait()
+    }
+
+    #[must_use]
+    pub fn set_contrast(self, contrast: f32) -> Self {
+        Self::from_dynamic_image(self.dynamic_image.adjust_contrast(contrast), self.format)
+    }
+
+    #[must_use]
+    pub fn set_brightness(self, brightness: i32) -> Self {
+        Self::from_dynamic_image(self.dynamic_image.brighten(brightness), self.format)
+    }
+
+    #[must_use]
+    pub fn set_blur(self, blur: f32) -> Self {
+        Self::from_dynamic_image(self.dynamic_image.blur(blur), self.format)
+    }
+
+    #[must_use]
+    pub fn autosplit(self, reading_order: ReadingOrder) -> (Image, Image) {
+        let img1 = Self::from_dynamic_image(
+            self.dynamic_image.crop_imm(
+                0,
+                0,
+                self.dynamic_image.width() / 2,
+                self.dynamic_image.height(),
+            ),
+            self.format,
+        );
+        let img2 = Self::from_dynamic_image(
+            self.dynamic_image.crop_imm(
+                self.dynamic_image.width() / 2,
+                0,
+                self.dynamic_image.width(),
+                self.dynamic_image.height(),
+            ),
+            self.format,
+        );
+        match reading_order {
+            ReadingOrder::Ltr => (img1, img2),
+            ReadingOrder::Rtl => (img2, img1),
+        }
+    }
+
+    pub fn set_format(&mut self, format: ImageFormat) -> &Self {
+        self.format = Some(format);
+        self
+    }
+
+    #[allow(clippy::missing_errors_doc)]
+    pub fn insert_into_cbz_writer(
+        self,
+        cbz_writer: &mut impl CbzWrite,
+        name: impl AsRef<str>,
+    ) -> Result<()> {
+        let mut out = Cursor::new(Vec::new());
+        let format = self.format.unwrap_or(ImageFormat::Png);
+        self.dynamic_image.write_to(&mut out, format)?;
+        let insertion = CbzWriterInsertionBuilder::from_extension(format.extensions_str()[0])
+            .set_bytes_ref(out.get_ref())
+            .build_custom_str(name.as_ref())?;
+        cbz_writer.insert_custom_str(insertion)?;
+        debug!("inserted page into zip");
+
+        Ok(())
+    }
+}

--- a/cbz/src/lib.rs
+++ b/cbz/src/lib.rs
@@ -17,7 +17,8 @@ use zip::{read::ZipFile, write::FileOptions, ZipArchive, ZipWriter};
 
 pub use crate::errors::{Error, Result};
 
-mod errors;
+pub mod errors;
+pub mod image;
 
 /// We artificially limit the amount of accepted files to 65535 files per Cbz
 /// First as it'd be rather impractical for the user to read such enormous Cbz


### PR DESCRIPTION
`cbz-pack` got revamped too as it used to allow for pdf packing but it now only accepts a glob of images to pack into a cbz.

The `cbz-converter` bin handles conversions from pdf and mobi/azw3 to cbz. Notice that for the latter the lack of proper spec and docs makes it a guess work and is not expected to work with literally every single mobi/azw3 files out there. More prs to come fixing what should be fixed.